### PR TITLE
feat(plugins): remove config and allow plugin elements

### DIFF
--- a/@dekk/deck/src/index.js
+++ b/@dekk/deck/src/index.js
@@ -129,6 +129,7 @@ export default class Deck extends Component {
     return plugins.map((plugin, index) =>
       cloneElement(plugin, {
         key: `${plugin.type.name}_${index}`,
+        ...this.store.publicMethods,
         slideIndex,
         slideCount,
         fragmentIndex,

--- a/@dekk/listener/src/index.js
+++ b/@dekk/listener/src/index.js
@@ -7,7 +7,7 @@ class Listener extends Component {
    */
   static get propTypes() {
     return {
-      onPage: PropTypes.func,
+      onSlide: PropTypes.func,
       onFragment: PropTypes.func
     }
   }
@@ -17,7 +17,7 @@ class Listener extends Component {
    */
   static get defaultProps() {
     return {
-      onPage: () => null,
+      onSlide: () => null,
       onFragment: () => null
     }
   }
@@ -26,6 +26,32 @@ class Listener extends Component {
    * @private
    * @param {Object} props
    *   The properties
+   * @param {number} props.slideCount
+   *   (Injected via Dekk)
+   * @param {number} props.onSlide
+   *   Callback when the slide changes
+   * @param {number} props.onFragment
+   *   Callback when the fragmnet changes
+   * @param {number} props.slideIndex
+   *   (Injected via Dekk)
+   * @param {number} props.fragmentCount
+   *   (Injected via Dekk)
+   * @param {number} props.fragmentIndex
+   *   (Injected via Dekk)
+   * @param {number} props.fragmnetOrder
+   *   (Injected via Dekk)
+   * @param {function} props.toFragment
+   *   (Injected via Dekk)
+   * @param {function} props.toSlide
+   *   (Injected via Dekk)
+   * @param {function} props.toNextFragment
+   *   (Injected via Dekk)
+   * @param {function} props.toPrevFragment
+   *   (Injected via Dekk)
+   * @param {function} props.toNextSlide
+   *   (Injected via Dekk)
+   * @param {function} props.toPrevSlide
+   *   (Injected via Dekk)
    */
   constructor(props) {
     super(props)
@@ -34,14 +60,14 @@ class Listener extends Component {
   /**
    * @private
    */
-  componentWillReceiveProps({page, fragment, fragmentCount}) {
+  componentWillReceiveProps({slideIndex, fragmentOrder, fragmentIndex}) {
     if (
-      this.props.fragmentCount !== fragmentCount &&
-      typeof fragment !== 'undefined'
+      this.props.fragmentIndex !== fragmentIndex &&
+      typeof fragmentOrder !== 'undefined'
     ) {
-      this.props.onFragment(page, fragmentCount, fragment)
-    } else if (this.props.page !== page) {
-      this.props.onPage(page)
+      this.props.onFragment(slideIndex, fragmentIndex, fragmentOrder)
+    } else if (this.props.slideIndex !== slideIndex) {
+      this.props.onSlide(slideIndex)
     }
   }
 

--- a/@dekk/paging/src/index.js
+++ b/@dekk/paging/src/index.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
  * This component does not render any content but adds paging via key
  * commands.
  *
- * If a page has fragments this component will split the page into
+ * If a pageIndex has fragments this component will split the pageIndex into
  * different steps.
  * Without this components fragments won't work. They are rendered as
  * normal elements but never get activated.
@@ -23,8 +23,24 @@ class Paging extends Component {
    */
   static get propTypes() {
     return {
-      trigger: PropTypes.oneOf(['keyup', 'keydown']).isRequired,
-      pages: PropTypes.number.isRequired
+      trigger: PropTypes.oneOf(['keyup', 'keydown']),
+      slideCount: PropTypes.number,
+      slideIndex: PropTypes.number,
+      fragmentCount: PropTypes.number,
+      fragmentIndex: PropTypes.number
+    }
+  }
+
+  /**
+   * @private
+   */
+  static get defaultProps() {
+    return {
+      trigger: 'keydown',
+      slideCount: 1,
+      slideIndex: 0,
+      fragmentCount: 0,
+      fragmentIndex: 0
     }
   }
 
@@ -43,7 +59,7 @@ class Paging extends Component {
    *   The properties
    * @param {String} props.trigger
    *   The event that triggers paging
-   * @param {number} props.pages
+   * @param {number} props.slideCount
    * @param {Object} context
    *   The context
    * @param {Object} context.store
@@ -71,7 +87,7 @@ class Paging extends Component {
   }
 
   /**
-   * Method to navigate to fragments or pages.
+   * Method to navigate to fragments or slideCount.
    * Uses left and right arrow buttons to navigate
    * @private
    * @param  {Object} e
@@ -80,43 +96,49 @@ class Paging extends Component {
    *   The keyCode that has been triggered by the event
    */
   goTo({which}) {
-    const {pages} = this.props
+    const {slideCount, slideIndex, fragmentIndex, fragmentCount} = this.props
     const {store} = this.context
     const {
-      page,
       toPreviousPage,
       toNextPage,
-      fragmentCount,
-      fragmentHosts,
       toNextFragment,
-      toPreviousFragment,
-      setFragment
+      toPreviousFragment
     } = store
-    const {length = 0} = fragmentHosts[page]
-    const previousFragment = Math.max(0, fragmentCount - 1)
-    const nextFragment = Math.min(length - 1, fragmentCount + 1)
-    const previousPage = Math.max(0, page - 1)
-    const nextPage = Math.min(pages - 1, page + 1)
+
+    const hasFragments = Boolean(fragmentCount)
+
+    const lastFragment = Math.max(0, fragmentCount - 1)
+
+    const previousFragment = Math.max(0, fragmentIndex - 1)
+    const nextFragment = Math.min(lastFragment, fragmentIndex + 1)
+
+    const lastSlide = Math.max(0, slideCount - 1)
+    const previousSlide = Math.max(0, slideIndex - 1)
+    const nextSlide = Math.min(lastSlide, slideIndex + 1)
+
+    const handleNext = () => {
+      if (hasFragments && nextFragment > fragmentIndex) {
+        toNextFragment()
+      } else if (nextSlide !== slideIndex) {
+        toNextPage()
+      }
+    }
+
+    const handlePrev = () => {
+      if (hasFragments && previousFragment < fragmentIndex) {
+        toPreviousFragment()
+      } else if (previousSlide !== slideIndex) {
+        toPreviousPage()
+      }
+    }
 
     // Switch between left and right arrow buttons
     switch (which) {
       case 39:
-        ;(() => {
-          if (length && nextFragment > fragmentCount) {
-            toNextFragment()
-          } else if (nextPage !== page) {
-            toNextPage()
-          }
-        })()
+        handleNext()
         break
       case 37:
-        ;(() => {
-          if (length && previousFragment < fragmentCount) {
-            toPreviousFragment()
-          } else if (previousPage !== page) {
-            toPreviousPage()
-          }
-        })()
+        handlePrev()
         break
       default:
         break

--- a/@dekk/paging/src/index.js
+++ b/@dekk/paging/src/index.js
@@ -24,6 +24,12 @@ class Paging extends Component {
   static get propTypes() {
     return {
       trigger: PropTypes.oneOf(['keyup', 'keydown']),
+      toNextFragment: PropTypes.func,
+      toPrevFragment: PropTypes.func,
+      toFragment: PropTypes.func,
+      toNextSlide: PropTypes.func,
+      toPrevSlide: PropTypes.func,
+      toSlide: PropTypes.func,
       slideCount: PropTypes.number,
       slideIndex: PropTypes.number,
       fragmentCount: PropTypes.number,
@@ -36,20 +42,7 @@ class Paging extends Component {
    */
   static get defaultProps() {
     return {
-      trigger: 'keydown',
-      slideCount: 1,
-      slideIndex: 0,
-      fragmentCount: 0,
-      fragmentIndex: 0
-    }
-  }
-
-  /**
-   * @private
-   */
-  static get contextTypes() {
-    return {
-      store: PropTypes.object.isRequired
+      trigger: 'keydown'
     }
   }
 
@@ -60,13 +53,30 @@ class Paging extends Component {
    * @param {String} props.trigger
    *   The event that triggers paging
    * @param {number} props.slideCount
-   * @param {Object} context
-   *   The context
-   * @param {Object} context.store
-   *   The mobx store passed through via context
+   *   (Injected via Dekk)
+   * @param {number} props.slideIndex
+   *   (Injected via Dekk)
+   * @param {number} props.fragmentCount
+   *   (Injected via Dekk)
+   * @param {number} props.fragmentIndex
+   *   (Injected via Dekk)
+   * @param {number} props.fragmnetOrder
+   *   (Injected via Dekk)
+   * @param {function} props.toFragment
+   *   (Injected via Dekk)
+   * @param {function} props.toSlide
+   *   (Injected via Dekk)
+   * @param {function} props.toNextFragment
+   *   (Injected via Dekk)
+   * @param {function} props.toPrevFragment
+   *   (Injected via Dekk)
+   * @param {function} props.toNextSlide
+   *   (Injected via Dekk)
+   * @param {function} props.toPrevSlide
+   *   (Injected via Dekk)
    */
-  constructor(props, context) {
-    super(props, context)
+  constructor(props) {
+    super(props)
     this.goTo = this.goTo.bind(this)
   }
 
@@ -96,14 +106,16 @@ class Paging extends Component {
    *   The keyCode that has been triggered by the event
    */
   goTo({which}) {
-    const {slideCount, slideIndex, fragmentIndex, fragmentCount} = this.props
-    const {store} = this.context
     const {
-      toPreviousPage,
-      toNextPage,
+      slideCount,
+      slideIndex,
+      fragmentIndex,
+      fragmentCount,
+      toNextSlide,
+      toPrevSlide,
       toNextFragment,
-      toPreviousFragment
-    } = store
+      toPrevFragment
+    } = this.props
 
     const hasFragments = Boolean(fragmentCount)
 
@@ -120,15 +132,15 @@ class Paging extends Component {
       if (hasFragments && nextFragment > fragmentIndex) {
         toNextFragment()
       } else if (nextSlide !== slideIndex) {
-        toNextPage()
+        toNextSlide()
       }
     }
 
     const handlePrev = () => {
       if (hasFragments && previousFragment < fragmentIndex) {
-        toPreviousFragment()
+        toPrevFragment()
       } else if (previousSlide !== slideIndex) {
-        toPreviousPage()
+        toPrevSlide()
       }
     }
 

--- a/@dekk/store/src/index.js
+++ b/@dekk/store/src/index.js
@@ -23,6 +23,17 @@ export default class Store {
     this.toPreviousFragment = this.toPreviousFragment.bind(this)
   }
 
+  get publicMethods() {
+    return {
+      toSlide: this.goToPage,
+      toNextSlide: this.toNextPage,
+      toPrevSlide: this.toPreviousPage,
+      toFragment: this.goToFragment,
+      toNextFragment: this.toNextFragment,
+      toPrevFragment: this.toPreviousFragment
+    }
+  }
+
   /**
    * @private
    */

--- a/@dekk/url/src/index.js
+++ b/@dekk/url/src/index.js
@@ -4,22 +4,24 @@ import PropTypes from 'prop-types'
 /**
  * @private
  */
-export const writeHash = (page = 0, fragment = 0) => {
-  window.location.hash = `#!/${page}/${fragment}/`
+export const writeHash = (slideIndex = 0, fragmentIndex = 0) => {
+  window.location.hash = `#!/${slideIndex}/${fragmentIndex}/`
 }
 
 /**
  * @private
  */
-export const writeQuery = (page = 0, fragment = 0, old = '') => {
+export const writeQuery = (slideIndex = 0, fragmentIndex = 0, old = '') => {
   const oldQuery = window.location.search
     .split(/[\?&]/)
     .filter(x => x !== '' && !x.match(/(page|fragment)/))
     .join('&')
   history.pushState(
-    {page, fragment},
-    `page ${page}, fragment ${fragment}`,
-    `?page=${page}&fragment=${fragment}${oldQuery ? `&${oldQuery}` : ''}`
+    {page: slideIndex, fragment: fragmentIndex},
+    `page ${slideIndex}, fragment ${fragmentIndex}`,
+    `?page=${slideIndex}&fragment=${fragmentIndex}${
+      oldQuery ? `&${oldQuery}` : ''
+    }`
   )
 }
 
@@ -33,8 +35,19 @@ class Url extends Component {
   static get propTypes() {
     return {
       type: PropTypes.oneOf(['hash', 'query']),
-      page: PropTypes.number,
-      fragmentCount: PropTypes.number
+      slideIndex: PropTypes.number,
+      fragmentIndex: PropTypes.number
+    }
+  }
+
+  /**
+   * @private
+   */
+  static get defaultProps() {
+    return {
+      type: 'hash',
+      slideIndex: 0,
+      fragmentIndex: 0
     }
   }
 
@@ -72,9 +85,9 @@ class Url extends Component {
    */
   hash(url) {
     const {hash = ''} = new URL(url)
-    const [, page = 0, fragment = 0] = hash.split('/')
-    this.context.store.goToPage(parseInt(page, 10))
-    this.context.store.goToFragment(parseInt(fragment, 10))
+    const [, slideIndex = 0, fragmentIndex = 0] = hash.split('/')
+    this.context.store.goToPage(parseInt(slideIndex, 10))
+    this.context.store.goToFragment(parseInt(fragmentIndex, 10))
   }
 
   /**
@@ -83,24 +96,27 @@ class Url extends Component {
   query(url) {
     const {search = ''} = new URL(url)
     const parts = search.split(/[\?&]/).filter(Boolean)
-    const {page = 0, fragment = 0} = parts.reduce((a, b) => {
-      const [key, value] = b.split('=')
-      return {...a, [key]: value}
-    }, {})
-    this.context.store.goToPage(parseInt(page, 10))
-    this.context.store.goToFragment(parseInt(fragment, 10))
+    const {page: slideIndex = 0, fragment: fragmentIndex = 0} = parts.reduce(
+      (a, b) => {
+        const [key, value] = b.split('=')
+        return {...a, [key]: value}
+      },
+      {}
+    )
+    this.context.store.goToPage(parseInt(slideIndex, 10))
+    this.context.store.goToFragment(parseInt(fragmentIndex, 10))
   }
 
   /**
    * @private
    */
-  componentWillReceiveProps({page, fragmentCount}) {
+  componentWillReceiveProps({slideIndex, fragmentIndex}) {
     switch (this.props.type) {
       case 'hash':
-        writeHash(page, fragmentCount)
+        writeHash(slideIndex, fragmentIndex)
         break
       case 'query':
-        writeQuery(page, fragmentCount)
+        writeQuery(slideIndex, fragmentIndex)
         break
       default:
         break

--- a/@dekk/url/src/index.js
+++ b/@dekk/url/src/index.js
@@ -26,7 +26,7 @@ export const writeQuery = (slideIndex = 0, fragmentIndex = 0, old = '') => {
 }
 
 /**
- * @private
+ * @public
  */
 class Url extends Component {
   /**
@@ -52,25 +52,34 @@ class Url extends Component {
   }
 
   /**
-   * @private
-   */
-  static get contextTypes() {
-    return {
-      store: PropTypes.object.isRequired
-    }
-  }
-
-  /**
-   * @private
+   * @public
    * @param {Object} props
    *   The properties
-   * @param {Object} context
-   *   The context
-   * @param {Object} context.store
-   *   The mobx store passed through via context
+   * @param {String} [props.type='hash']
+   *   Either `hash` or `query` to enable hash(bang) or search query URLs
+   * @param {number} props.slideIndex
+   *   (private: Injected via Dekk)
+   * @param {number} props.fragmentCount
+   *   (private: Injected via Dekk)
+   * @param {number} props.fragmentIndex
+   *   (private: Injected via Dekk)
+   * @param {number} props.fragmnetOrder
+   *   (private: Injected via Dekk)
+   * @param {function} props.toFragment
+   *   (private: Injected via Dekk)
+   * @param {function} props.toSlide
+   *   (private: Injected via Dekk)
+   * @param {function} props.toNextFragment
+   *   (private: Injected via Dekk)
+   * @param {function} props.toPrevFragment
+   *   (private: Injected via Dekk)
+   * @param {function} props.toNextSlide
+   *   (private: Injected via Dekk)
+   * @param {function} props.toPrevSlide
+   *   (private: Injected via Dekk)
    */
-  constructor(props, context) {
-    super(props, context)
+  constructor(props) {
+    super(props)
   }
 
   /**
@@ -86,8 +95,8 @@ class Url extends Component {
   hash(url) {
     const {hash = ''} = new URL(url)
     const [, slideIndex = 0, fragmentIndex = 0] = hash.split('/')
-    this.context.store.goToPage(parseInt(slideIndex, 10))
-    this.context.store.goToFragment(parseInt(fragmentIndex, 10))
+    this.toSlide(slideIndex)
+    this.toFragment(fragmentIndex)
   }
 
   /**
@@ -103,8 +112,22 @@ class Url extends Component {
       },
       {}
     )
-    this.context.store.goToPage(parseInt(slideIndex, 10))
-    this.context.store.goToFragment(parseInt(fragmentIndex, 10))
+    this.toSlide(slideIndex)
+    this.toFragment(fragmentIndex)
+  }
+
+  /**
+   * @private
+   */
+  toFragment(fragmentIndex) {
+    this.props.toFragment(parseInt(fragmentIndex, 10))
+  }
+
+  /**
+   * @private
+   */
+  toSlide(slideIndex) {
+    this.props.toSlide(parseInt(slideIndex, 10))
   }
 
   /**

--- a/gh-pages/gh-pages.js
+++ b/gh-pages/gh-pages.js
@@ -1,14 +1,57 @@
 import React from 'react'
 import {render} from 'react-dom'
+import styled from 'styled-components'
 
-import Deck from '@dekk/deck'
+import Deck, {Plugins} from '@dekk/deck'
 import Fragment from '@dekk/fragment'
+import Url from '@dekk/url'
 import Slide from '@dekk/slide'
+import Paging from '@dekk/paging'
+import Listener from '@dekk/listener'
+
+const handleSlide = slideIndex => {
+  console.log(slideIndex)
+}
+
+const StyledPageNumber = styled.div`
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  background: #222;
+  color: #fff;
+  height: 2rem;
+  width: 6rem;
+  display: flex;
+  align-items: center;
+  align-content: center;
+  justify-content: center;
+  font-family: sans-serif;
+`
+const PageNumber = props => {
+  return (
+    <StyledPageNumber>
+      {props.slideIndex + 1} / {props.slideCount}
+    </StyledPageNumber>
+  )
+}
 
 const App = () => (
   <Deck>
+    <Plugins>
+      <Paging />
+      <Url />
+      <Listener onSlide={handleSlide} />
+    </Plugins>
+    <Plugins>
+      <PageNumber />
+    </Plugins>
     <Slide>
-      Slide <Fragment order={1}>1</Fragment>
+      <Fragment order={0}>0</Fragment>
+      <Fragment order={1}>1</Fragment>
+      <Fragment order={2}>2</Fragment>
+      <Fragment order={3}>3</Fragment>
+      <Fragment order={4}>4</Fragment>
+      <Fragment order={5}>5</Fragment>
     </Slide>
     <Slide>Slide 2</Slide>
     <Slide>Slide 3</Slide>


### PR DESCRIPTION
Plugins can be nested in a special component. They are filled with additional props <strike>and gain access
to the context (including the store)</strike>

<!-- List motivation and changes here -->
## Motivation

We needed a better way to allow plugins.
This change will allow nesting elements in special components `<Plugins />`

You could define a multiple of these containers. This allows storing configurations as importable collections.

```jsx
const myPlugins = (
<Plugins>
  <MyCustomPlugin/>
  <AnotherCustomPlugin/>
</Plugins>
)


const App = () => (
  <Deck>
    <Plugins>
      <Paging trigger='keydown'/>
      <Url />
    </Plugins>
    {myPlugins}
    <Slide>Slide 1</Slide>
    <Slide>Slide 2</Slide>
    <Slide>Slide 3</Slide>
  </Deck>
)
```


<!-- List closed issues here -->
## Issues closed

closes #5  
closes #10  
closes #11  
fixes #9  

<!-- Checklist -->

## Compatibility tests

- [ ] All tests pass  
- [ ] New test were written


## Intended version

- [ ] Patch
- [ ] Minor
- [ ] Major
- [x] 1.0.0 (first release)
